### PR TITLE
Use assembly names to sort viewer output for Linux compatibility

### DIFF
--- a/Source/Testing/Viewer.cs
+++ b/Source/Testing/Viewer.cs
@@ -152,7 +152,7 @@ namespace RimTest.Testing
         public static void LogTestsResults()
         {
             List<Assembly> asms = GetAssemblies();
-            asms.Sort();
+            asms.SortBy(asm => asm.FullName);
             if (!RimTestMod.Settings.RunOwnTests)
                 asms.Remove(Assembly.GetExecutingAssembly());
 


### PR DESCRIPTION
On Linux versions of .net, Assemblies don't implement `IComparable`. Sorting by name instead fixes compatibility when the viewer runs.

```
Error while instantiating a mod of type RimTest.RimTestMod: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.InvalidOperationException: Failed to compare two elements in the array. ---> System.ArgumentException: At least one object must implement IComparable.
  at System.Collections.Comparer.Compare (System.Object a, System.Object b) [0x00069] in <567df3e0919241ba98db88bec4c6696f>:0 
  at System.Collections.Generic.ObjectComparer`1[T].Compare (T x, T y) [0x00000] in <567df3e0919241ba98db88bec4c6696f>:0 
  at System.Collections.Generic.ArraySortHelper`1[T].SwapIfGreater (T[] keys, System.Comparison`1[T] comparer, System.Int32 a, System.Int32 b) [0x00004] in <567df3e0919241ba98db88bec4c6696f>:0 
  at System.Collections.Generic.ArraySortHelper`1[T].IntroSort (T[] keys, System.Int32 lo, System.Int32 hi, System.Int32 depthLimit, System.Comparison`1[T] comparer) [0x00019] in <567df3e0919241ba98db88bec4c6696f>:0 
  at System.Collections.Generic.ArraySortHelper`1[T].IntrospectiveSort (T[] keys, System.Int32 left, System.Int32 length, System.Comparison`1[T] comparer) [0x00015] in <567df3e0919241ba98db88bec4c6696f>:0 
  at System.Collections.Generic.ArraySortHelper`1[T].Sort (T[] keys, System.Int32 index, System.Int32 length, System.Collections.Generic.IComparer`1[T] comparer) [0x0001a] in <567df3e0919241ba98db88bec4c6696f>:0 
   --- End of inner exception stack trace ---
  at System.Collections.Generic.ArraySortHelper`1[T].Sort (T[] keys, System.Int32 index, System.Int32 length, System.Collections.Generic.IComparer`1[T] comparer) [0x00036] in <567df3e0919241ba98db88bec4c6696f>:0 
  at System.Array.Sort[T] (T[] array, System.Int32 index, System.Int32 length, System.Collections.Generic.IComparer`1[T] comparer) [0x00048] in <567df3e0919241ba98db88bec4c6696f>:0 
  at System.Collections.Generic.List`1[T].Sort (System.Int32 index, System.Int32 count, System.Collections.Generic.IComparer`1[T] comparer) [0x0002a] in <567df3e0919241ba98db88bec4c6696f>:0 
  at System.Collections.Generic.List`1[T].Sort () [0x00008] in <567df3e0919241ba98db88bec4c6696f>:0 
  at RimTest.Testing.Viewer.LogTestsResults () [0x00007] in <cac0e097f68a4696a355a8b16877b3bc>:0 
  at RimTest.RimTestMod..ctor (Verse.ModContentPack content) [0x0003c] in <cac0e097f68a4696a355a8b16877b3bc>:0 
  at (wrapper managed-to-native) System.Reflection.MonoCMethod.InternalInvoke(System.Reflection.MonoCMethod,object,object[],System.Exception&)
  at System.Reflection.MonoCMethod.InternalInvoke (System.Object obj, System.Object[] parameters) [0x00002] in <567df3e0919241ba98db88bec4c6696f>:0 
   --- End of inner exception stack trace ---
  at System.Reflection.MonoCMethod.InternalInvoke (System.Object obj, System.Object[] parameters) [0x00014] in <567df3e0919241ba98db88bec4c6696f>:0 
  at System.Reflection.MonoCMethod.DoInvoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0007a] in <567df3e0919241ba98db88bec4c6696f>:0 
  at System.Reflection.MonoCMethod.Invoke (System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00000] in <567df3e0919241ba98db88bec4c6696f>:0 
  at System.RuntimeType.CreateInstanceImpl (System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Object[] args, System.Globalization.CultureInfo culture, System.Object[] activationAttributes, System.Threading.StackCrawlMark& stackMark) [0x00213] in <567df3e0919241ba98db88bec4c6696f>:0 
  at System.Activator.CreateInstance (System.Type type, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder binder, System.Object[] args, System.Globalization.CultureInfo culture, System.Object[] activationAttributes) [0x00095] in <567df3e0919241ba98db88bec4c6696f>:0 
  at System.Activator.CreateInstance (System.Type type, System.Object[] args) [0x00000] in <567df3e0919241ba98db88bec4c6696f>:0 
  at Verse.LoadedModManager.CreateModClasses () [0x00076] in <8ab778f913ea4941b17d6942d15c2508>:0 
Verse.Log:Error(String, Boolean)
Verse.LoadedModManager:CreateModClasses()
Verse.LoadedModManager:LoadAllActiveMods()
Verse.PlayDataLoader:DoPlayLoad()
Verse.PlayDataLoader:LoadAllPlayData(Boolean)
Verse.<>c:<Start>b__6_1()
Verse.LongEventHandler:RunEventFromAnotherThread(Action)
Verse.<>c:<UpdateCurrentAsynchronousEvent>b__27_0()
System.Threading.ThreadHelper:ThreadStart_Context(Object)
System.Threading.ExecutionContext:RunInternal(ExecutionContext, ContextCallback, Object, Boolean)
System.Threading.ExecutionContext:Run(ExecutionContext, ContextCallback, Object, Boolean)
System.Threading.ExecutionContext:Run(ExecutionContext, ContextCallback, Object)
System.Threading.ThreadHelper:ThreadStart()
```